### PR TITLE
fix(ui): preview pane corner crescents and crop mode layout

### DIFF
--- a/Controllers/FloatingWindowController.swift
+++ b/Controllers/FloatingWindowController.swift
@@ -37,6 +37,10 @@ final class FloatingWindowController {
             .environmentObject(coordinator)
 
         let hosting = NSHostingController(rootView: rootView)
+        hosting.view.wantsLayer = true
+        hosting.view.layer?.cornerRadius = 18
+        hosting.view.layer?.cornerCurve = .continuous
+        hosting.view.layer?.masksToBounds = true
 
         let p = GlassPanel(
             contentRect: NSRect(x: 0, y: 0, width: 380, height: 620),

--- a/Views/ContentView.swift
+++ b/Views/ContentView.swift
@@ -29,6 +29,7 @@ struct ContentView: View {
         .frame(minWidth: 340, minHeight: 520)
         .background(reduceTransparency ? AnyShapeStyle(Color(nsColor: .windowBackgroundColor)) : AnyShapeStyle(.ultraThinMaterial),
                     in: RoundedRectangle(cornerRadius: 18))
+        .clipShape(RoundedRectangle(cornerRadius: 18))
         .overlay(RoundedRectangle(cornerRadius: 18).strokeBorder(.white.opacity(0.18), lineWidth: 0.5))
         .sheet(isPresented: $showSettings) {
             SettingsView()
@@ -79,8 +80,9 @@ struct ContentView: View {
                 session: captureManager.captureSession,
                 cropMode: captureManager.cropMode
             )
-            .aspectRatio(previewAspectRatio, contentMode: .fit)
             .frame(maxWidth: .infinity)
+            .aspectRatio(previewAspectRatio, contentMode: .fill)
+            .clipped()
             .background(Color.black)
 
             if captureManager.isRecording {

--- a/Views/ContentView.swift
+++ b/Views/ContentView.swift
@@ -81,21 +81,13 @@ struct ContentView: View {
                 cropMode: captureManager.cropMode
             )
             .frame(maxWidth: .infinity)
-            .aspectRatio(previewAspectRatio, contentMode: .fill)
+            .aspectRatio(16.0 / 9.0, contentMode: .fill)
             .clipped()
             .background(Color.black)
 
             if captureManager.isRecording {
                 recordingBadge
             }
-        }
-    }
-
-    private var previewAspectRatio: CGFloat {
-        switch captureManager.cropMode {
-        case .none:     return 16.0 / 9.0
-        case .square:   return 1.0
-        case .vertical: return 9.0 / 16.0
         }
     }
 


### PR DESCRIPTION
## Summary

- **Corner overhang fix**: Clips `AVCaptureVideoPreviewLayer` at the AppKit level (`NSHostingController` root view layer gets `cornerRadius=18`, `cornerCurve=.continuous`, `masksToBounds=true`), so the raw CALayer sublayer no longer bleeds outside the rounded rect in Full Frame mode.
- **Crop mode layout fix**: Preview pane height is now always fixed at 16:9. Square and Vertical modes show black crop bars via the existing `overlayLayer` in `CameraPreviewNSView` rather than shrinking the SwiftUI frame and pushing controls off-screen.

## Test plan
- [ ] Full Frame mode: no corner crescents visible
- [ ] Square mode: black bars on left/right; window height unchanged
- [ ] Vertical (9:16) mode: black bars on left/right; window height unchanged
- [ ] Controls remain fully visible in all crop modes
- [ ] Recording badge overlay renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)