### PR TITLE
Fix countdown re-entry and writer error reporting

### DIFF
--- a/App/RecordingCoordinator.swift
+++ b/App/RecordingCoordinator.swift
@@ -6,6 +6,7 @@ final class RecordingCoordinator: ObservableObject {
 
     let captureManager: CaptureManager
     weak var floatingWindowController: FloatingWindowController?
+    @Published private(set) var isCountingDown = false
 
     private lazy var countdownController = CountdownWindowController()
     private lazy var hudController = RecordingHUDController(captureManager: captureManager)
@@ -21,10 +22,16 @@ final class RecordingCoordinator: ObservableObject {
     }
 
     func startFlow() {
+        guard !captureManager.isRecording, !isCountingDown else { return }
+        isCountingDown = true
         floatingWindowController?.hide(stopCamera: false)  // keep session live through countdown
         countdownController.show(from: 3) { [weak self] in
             guard let self else { return }
-            self.captureManager.startRecording()
+            self.isCountingDown = false
+            guard self.captureManager.startRecording() else {
+                self.floatingWindowController?.show()
+                return
+            }
             self.hudController.show()
             self.registerSpeedHotkeys()
             NSAccessibility.post(
@@ -36,6 +43,7 @@ final class RecordingCoordinator: ObservableObject {
     }
 
     func stopFlow() {
+        guard captureManager.isRecording else { return }
         unregisterSpeedHotkeys()
         speedOverlay.dismiss()
         captureManager.stopRecording()
@@ -51,6 +59,7 @@ final class RecordingCoordinator: ObservableObject {
     // MARK: - Speed hotkeys (↑ / ↓ during recording)
 
     private func registerSpeedHotkeys() {
+        guard speedHandlerRef == nil, upHotkeyRef == nil, dnHotkeyRef == nil else { return }
         var spec = EventTypeSpec(eventClass: OSType(kEventClassKeyboard),
                                  eventKind: UInt32(kEventHotKeyPressed))
         let selfPtr = Unmanaged.passUnretained(self).toOpaque()

--- a/Capture/CaptureManager.swift
+++ b/Capture/CaptureManager.swift
@@ -48,6 +48,7 @@ final class CaptureManager: NSObject, ObservableObject {
     private var sessionStarted = false
     private var isRecordingInternal = false
     private var activeCropRect: CGRect = .zero
+    private var writerFailureReported = false
 
     private var durationTimer: Timer?
 
@@ -398,10 +399,18 @@ final class CaptureManager: NSObject, ObservableObject {
 
     // MARK: - Recording
 
-    func toggleRecording() { isRecording ? stopRecording() : startRecording() }
+    func toggleRecording() {
+        if isRecording {
+            stopRecording()
+        } else {
+            _ = startRecording()
+        }
+    }
 
-    func startRecording() {
-        guard !isRecording else { return }
+    @discardableResult
+    func startRecording() -> Bool {
+        guard !isRecording else { return false }
+        lastError = nil
 
         let sourceDims: CMVideoDimensions
         if let camera = selectedCamera {
@@ -417,7 +426,7 @@ final class CaptureManager: NSObject, ObservableObject {
 
         guard let writer = try? AVAssetWriter(outputURL: outputURL, fileType: fileType) else {
             DispatchQueue.main.async { self.lastError = "Could not create output file at \(outputURL.path)." }
-            return
+            return false
         }
 
         // Video writer input
@@ -450,6 +459,13 @@ final class CaptureManager: NSObject, ObservableObject {
                     sourcePixelBufferAttributes: pixelAttrs
                 )
             }
+
+            guard vInput != nil else {
+                DispatchQueue.main.async {
+                    self.lastError = "Could not configure video encoding for the recording."
+                }
+                return false
+            }
         }
 
         // Audio writer input
@@ -473,9 +489,24 @@ final class CaptureManager: NSObject, ObservableObject {
         }
         let ai = AVAssetWriterInput(mediaType: .audio, outputSettings: aSettings)
         ai.expectsMediaDataInRealTime = true
-        if writer.canAdd(ai) { writer.add(ai) }
+        guard writer.canAdd(ai) else {
+            DispatchQueue.main.async {
+                self.lastError = "Could not configure audio encoding for the recording."
+            }
+            return false
+        }
+        writer.add(ai)
 
-        writer.startWriting()
+        guard writer.startWriting() else {
+            DispatchQueue.main.async {
+                self.lastError = self.writerErrorMessage(
+                    prefix: "Could not start recording",
+                    writer: writer,
+                    outputURL: outputURL
+                )
+            }
+            return false
+        }
 
         outputQueue.async { [weak self] in
             guard let self else { return }
@@ -486,6 +517,7 @@ final class CaptureManager: NSObject, ObservableObject {
             self.activeCropRect     = cropRect
             self.sessionStarted     = false
             self.isRecordingInternal = true
+            self.writerFailureReported = false
         }
 
         isRecording = true
@@ -494,6 +526,7 @@ final class CaptureManager: NSObject, ObservableObject {
         durationTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
             self?.recordingDuration += 1
         }
+        return true
     }
 
     func stopRecording() {
@@ -512,12 +545,25 @@ final class CaptureManager: NSObject, ObservableObject {
             self.videoWriterInput?.markAsFinished()
             self.audioWriterInput?.markAsFinished()
             let writer = self.assetWriter
+            let outputURL = writer?.outputURL
             self.assetWriter        = nil
             self.videoWriterInput   = nil
             self.audioWriterInput   = nil
             self.pixelBufferAdaptor = nil
             self.sessionStarted     = false
-            writer?.finishWriting {}
+            switch writer?.status {
+            case .some(.writing):
+                writer?.finishWriting { [weak self] in
+                    self?.handleWriterCompletion(writer, outputURL: outputURL)
+                }
+            case .some(.unknown):
+                writer?.cancelWriting()
+                self.handleWriterCompletion(writer, outputURL: outputURL)
+            case .some:
+                self.handleWriterCompletion(writer, outputURL: outputURL)
+            case .none:
+                break
+            }
         }
     }
 
@@ -553,6 +599,60 @@ final class CaptureManager: NSObject, ObservableObject {
         let ext = recordingMode == .audioOnly ? AppSettings.shared.audioFormat.fileExtension : "mov"
         let name = "Radcap_\(fmt.string(from: Date())).\(ext)"
         return AppSettings.shared.effectiveOutputDirectory.appendingPathComponent(name)
+    }
+
+    private func handleWriterCompletion(_ writer: AVAssetWriter?, outputURL: URL?) {
+        guard let writer else { return }
+
+        switch writer.status {
+        case .completed:
+            log.info("Recording finalized successfully at \(outputURL?.path ?? writer.outputURL.path)")
+        case .failed:
+            publishWriterFailureIfNeeded(
+                writerErrorMessage(
+                    prefix: "Recording could not be saved",
+                    writer: writer,
+                    outputURL: outputURL
+                )
+            )
+        case .cancelled:
+            publishWriterFailureIfNeeded(
+                writerErrorMessage(
+                    prefix: "Recording was cancelled before it could be saved",
+                    writer: writer,
+                    outputURL: outputURL
+                )
+            )
+        case .unknown:
+            publishWriterFailureIfNeeded(
+                writerErrorMessage(
+                    prefix: "Recording stopped before the file could be finalized",
+                    writer: writer,
+                    outputURL: outputURL
+                )
+            )
+        case .writing:
+            publishWriterFailureIfNeeded("Recording is still writing and did not finish cleanly.")
+        @unknown default:
+            publishWriterFailureIfNeeded("Recording ended in an unknown writer state.")
+        }
+    }
+
+    private func writerErrorMessage(prefix: String, writer: AVAssetWriter, outputURL: URL?) -> String {
+        let fileDescription = outputURL?.lastPathComponent ?? writer.outputURL.lastPathComponent
+        if let error = writer.error?.localizedDescription, !error.isEmpty {
+            return "\(prefix) for \(fileDescription): \(error)"
+        }
+        return "\(prefix) for \(fileDescription)."
+    }
+
+    private func publishWriterFailureIfNeeded(_ message: String) {
+        guard !writerFailureReported else { return }
+        writerFailureReported = true
+        log.error("\(message)")
+        DispatchQueue.main.async { [weak self] in
+            self?.lastError = message
+        }
     }
 
     var durationString: String {
@@ -618,8 +718,21 @@ extension CaptureManager: AVCaptureVideoDataOutputSampleBufferDelegate,
         }
 
         guard isRecordingInternal,
-              let writer = assetWriter,
-              writer.status == .writing else { return }
+              let writer = assetWriter else { return }
+
+        if writer.status == .failed || writer.status == .cancelled {
+            isRecordingInternal = false
+            publishWriterFailureIfNeeded(
+                writerErrorMessage(
+                    prefix: "Recording failed while writing",
+                    writer: writer,
+                    outputURL: writer.outputURL
+                )
+            )
+            return
+        }
+
+        guard writer.status == .writing else { return }
 
         let pts = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
 

--- a/Controllers/CountdownWindowController.swift
+++ b/Controllers/CountdownWindowController.swift
@@ -5,6 +5,7 @@ final class CountdownWindowController {
     private var window: NSWindow?
 
     func show(from count: Int = 3, completion: @escaping () -> Void) {
+        guard window == nil else { return }
         guard let screen = NSScreen.main else {
             completion()
             return

--- a/Views/ContentView.swift
+++ b/Views/ContentView.swift
@@ -15,6 +15,13 @@ struct ContentView: View {
 
     let onClose: () -> Void
 
+    private var errorAlertBinding: Binding<Bool> {
+        Binding(
+            get: { captureManager.lastError != nil },
+            set: { if !$0 { captureManager.lastError = nil } }
+        )
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             windowChrome
@@ -34,6 +41,13 @@ struct ContentView: View {
         .sheet(isPresented: $showSettings) {
             SettingsView()
                 .environmentObject(settings)
+        }
+        .alert("Recording Error", isPresented: errorAlertBinding, presenting: captureManager.lastError) { _ in
+            Button("OK") {
+                captureManager.lastError = nil
+            }
+        } message: { message in
+            Text(message)
         }
     }
 
@@ -220,9 +234,9 @@ struct ContentView: View {
             }
         } label: {
             HStack(spacing: 6) {
-                Image(systemName: captureManager.isRecording ? "stop.circle.fill" : "record.circle.fill")
+                Image(systemName: captureManager.isRecording ? "stop.circle.fill" : (coordinator.isCountingDown ? "timer" : "record.circle.fill"))
                     .foregroundColor(captureManager.isRecording ? .primary : .red)
-                Text(captureManager.isRecording ? "Stop" : "Record")
+                Text(captureManager.isRecording ? "Stop" : (coordinator.isCountingDown ? "Starting…" : "Record"))
                     .fontWeight(.semibold)
             }
             .frame(minWidth: 90)
@@ -230,7 +244,7 @@ struct ContentView: View {
         .buttonStyle(.bordered)
         .controlSize(.large)
         .keyboardShortcut("r", modifiers: [.command, .option])
-        .disabled(!captureManager.sessionRunning && !captureManager.isRecording)
+        .disabled((!captureManager.sessionRunning && !captureManager.isRecording) || coordinator.isCountingDown)
     }
 
     private var cameraPicker: some View {


### PR DESCRIPTION
## Summary
- prevent duplicate recording starts while the countdown is already in progress
- make the countdown window idempotent and expose countdown state to the setup UI
- surface recording start/finalization failures through `lastError` and a visible alert
- validate writer setup/finalization paths instead of silently ignoring `AVAssetWriter` failures

## Issues
Closes #18
Closes #20

## Verification
- built with `xcodebuild -project Radcap.xcodeproj -scheme Radcap -configuration Debug -derivedDataPath .derivedData CODE_SIGNING_ALLOWED=NO build`

## Notes
- `.derivedData/` was generated locally for verification and is not part of the commit.