### PR TITLE
Add explicit teleprompter privacy controls

### DIFF
--- a/Capture/CaptureManager.swift
+++ b/Capture/CaptureManager.swift
@@ -280,11 +280,11 @@ final class CaptureManager: NSObject, ObservableObject {
         alert.informativeText = """
             Radcap's microphone permission has become stale — this can happen after updating, reinstalling, or running diagnostics on the app.
 
-            To fix, open Terminal and run this command:
+            To fix, open Terminal and run this command for your current macOS user:
 
-                sudo tccutil reset Microphone com.sfegette.radcap
+                tccutil reset Microphone com.sfegette.radcap
 
-            Then restart your Mac and relaunch Radcap. macOS will prompt for microphone access.
+            No admin privileges are required. After it completes, relaunch Radcap and macOS will prompt for microphone access again.
             """
         alert.alertStyle = .warning
         alert.addButton(withTitle: "Open Terminal")

--- a/Models/AppSettings.swift
+++ b/Models/AppSettings.swift
@@ -21,6 +21,7 @@ final class AppSettings: ObservableObject {
         static let outputDirectoryPath          = "outputDirectoryPath"
         static let outputDirectoryBookmark      = "outputDirectoryBookmark"
         static let audioFormat                  = "audioFormat"
+        static let persistTeleprompterText      = "persistTeleprompterText"
         static let teleprompterText             = "teleprompterText"
         static let teleprompterSpeed            = "teleprompterSpeed"
         static let teleprompterFontSize         = "teleprompterFontSize"
@@ -54,8 +55,14 @@ final class AppSettings: ObservableObject {
             }
         }
     }
+    @Published var persistTeleprompterText: Bool {
+        didSet {
+            UserDefaults.standard.set(persistTeleprompterText, forKey: Key.persistTeleprompterText)
+            persistTeleprompterTextIfNeeded()
+        }
+    }
     @Published var teleprompterText: String {
-        didSet { UserDefaults.standard.set(teleprompterText, forKey: Key.teleprompterText) }
+        didSet { persistTeleprompterTextIfNeeded() }
     }
     @Published var teleprompterSpeed: Double {
         didSet { UserDefaults.standard.set(teleprompterSpeed, forKey: Key.teleprompterSpeed) }
@@ -106,7 +113,17 @@ final class AppSettings: ObservableObject {
         } else if let path = UserDefaults.standard.string(forKey: Key.outputDirectoryPath) {
             outputDirectory = URL(fileURLWithPath: path)
         }
-        teleprompterText = UserDefaults.standard.string(forKey: Key.teleprompterText) ?? ""
+        let defaults = UserDefaults.standard
+        let legacyTeleprompterText = defaults.string(forKey: Key.teleprompterText)
+        let shouldPersistTeleprompterText: Bool
+        if defaults.object(forKey: Key.persistTeleprompterText) != nil {
+            shouldPersistTeleprompterText = defaults.bool(forKey: Key.persistTeleprompterText)
+        } else {
+            // Preserve existing users' saved scripts after upgrade, but default new users to session-only storage.
+            shouldPersistTeleprompterText = (legacyTeleprompterText?.isEmpty == false)
+        }
+        persistTeleprompterText = shouldPersistTeleprompterText
+        teleprompterText = shouldPersistTeleprompterText ? (legacyTeleprompterText ?? "") : ""
         let speed = UserDefaults.standard.double(forKey: Key.teleprompterSpeed)
         teleprompterSpeed = speed > 0 ? min(max(speed, 0.25), 2.0) : 0.7
         let size = UserDefaults.standard.double(forKey: Key.teleprompterFontSize)
@@ -126,9 +143,22 @@ final class AppSettings: ObservableObject {
         audioFormat = AudioFormat(rawValue: fmtRaw) ?? .m4a
     }
 
+    func clearTeleprompterText() {
+        teleprompterText = ""
+        UserDefaults.standard.removeObject(forKey: Key.teleprompterText)
+    }
+
     var effectiveOutputDirectory: URL {
         if let dir = outputDirectory { return dir }
         let fallbackSearch: FileManager.SearchPathDirectory = AppSettings.isSandboxed ? .moviesDirectory : .desktopDirectory
         return FileManager.default.urls(for: fallbackSearch, in: .userDomainMask)[0]
+    }
+
+    private func persistTeleprompterTextIfNeeded() {
+        if persistTeleprompterText {
+            UserDefaults.standard.set(teleprompterText, forKey: Key.teleprompterText)
+        } else {
+            UserDefaults.standard.removeObject(forKey: Key.teleprompterText)
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ Grab the latest build from the [Releases](https://github.com/sfegette/radcap/rel
 
 Recordings are saved to the Desktop by default (`Radcap_YYYY-MM-DD_HHmmss.mov`). The output directory can be changed in Settings.
 
+## Privacy
+
+Teleprompter text is session-only by default. If you want Radcap to remember your script between launches, enable **Remember script between launches** in Settings. You can also clear the current script from Settings at any time.
+
 ---
 
 ## FAQ

--- a/Views/SettingsView.swift
+++ b/Views/SettingsView.swift
@@ -73,6 +73,8 @@ struct SettingsView: View {
                 }
 
                 Section("Teleprompter") {
+                    Toggle("Remember script between launches", isOn: $settings.persistTeleprompterText)
+
                     LabeledContent("Font Size") {
                         HStack {
                             Slider(value: $settings.teleprompterFontSize, in: 16...72, step: 2)
@@ -124,6 +126,19 @@ struct SettingsView: View {
                                 parse: { Double($0.trimmingCharacters(in: .whitespaces)) }
                             )
                         }
+                    }
+
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(settings.persistTeleprompterText
+                             ? "Your script is stored locally on this Mac until you clear it."
+                             : "Your script stays in memory for this launch only and is removed from local settings.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Button("Clear Script") {
+                            settings.clearTeleprompterText()
+                        }
+                        .buttonStyle(.borderless)
+                        .disabled(settings.teleprompterText.isEmpty)
                     }
                 }
 
@@ -232,4 +247,3 @@ private extension URL {
         (path as NSString).abbreviatingWithTildeInPath
     }
 }
-


### PR DESCRIPTION
## Summary
- make teleprompter script persistence an explicit setting instead of always storing it implicitly
- preserve existing users' saved scripts after upgrade, while defaulting new users to session-only script storage
- add a one-click clear action for the current/saved script
- remove the unnecessary `sudo` from the microphone reset guidance and clarify that the reset is per-user
- document the new privacy behavior in the README

## Issue
Closes #21

## Verification
- built with `xcodebuild -project Radcap.xcodeproj -scheme Radcap -configuration Debug -derivedDataPath .derivedData CODE_SIGNING_ALLOWED=NO build`

## Notes
- `.derivedData/` was generated locally for verification and is not part of the commit.