### PR TITLE
fix(ui): square off controls panel top corners

### DIFF
--- a/Views/ContentView.swift
+++ b/Views/ContentView.swift
@@ -216,7 +216,10 @@ struct ContentView: View {
             }
         }
         .padding(10)
-        .background(reduceTransparency ? AnyShapeStyle(Color(nsColor: .controlBackgroundColor)) : AnyShapeStyle(.regularMaterial))
+        .background(
+            reduceTransparency ? AnyShapeStyle(Color(nsColor: .controlBackgroundColor)) : AnyShapeStyle(.regularMaterial),
+            in: UnevenRoundedRectangle(topLeadingRadius: 0, bottomLeadingRadius: 18, bottomTrailingRadius: 18, topTrailingRadius: 0)
+        )
     }
 
     private var recordButton: some View {


### PR DESCRIPTION
Closes #30

## Summary
- Replaces the `controlsSection` plain `.regularMaterial` background with an `UnevenRoundedRectangle` that has **0pt top-corner radii** and **18pt bottom-corner radii**
- Bottom radii match the outer window's `clipShape(RoundedRectangle(cornerRadius: 18))`, so the bottom of the window stays visually consistent
- The top edge of the controls panel is now a clean straight line, making it look like the panel slides out from beneath the teleprompter
- `UnevenRoundedRectangle` available since macOS 13; deployment target is 14.0

## Test plan
- [ ] Launch the app and confirm the top corners of the controls section are flat (not rounded) where it meets the teleprompter area
- [ ] Confirm the bottom-left and bottom-right window corners are still rounded
- [ ] Enable **Reduce Transparency** in System Settings → Accessibility and confirm the solid fallback background also has flat top corners
- [ ] Resize the window and verify no visual artifacts at any width

🤖 Generated with [Claude Code](https://claude.com/claude-code)