### PR TITLE
feat(settings): add video format picker (MOV / MP4)

### DIFF
--- a/Capture/CaptureManager.swift
+++ b/Capture/CaptureManager.swift
@@ -452,9 +452,11 @@ final class CaptureManager: NSObject, ObservableObject {
             }
         }
 
-        // Audio writer input
+        // Audio writer input — MP4 container requires AAC; WAV (Linear PCM) is incompatible.
         let aSettings: [String: Any]
-        if AppSettings.shared.audioFormat == .wav {
+        let useLinearPCM = AppSettings.shared.audioFormat == .wav
+            && !(recordingMode != .audioOnly && AppSettings.shared.videoFormat == .mp4)
+        if useLinearPCM {
             aSettings = [
                 AVFormatIDKey:                kAudioFormatLinearPCM,
                 AVSampleRateKey:              44100.0,

--- a/Capture/CaptureManager.swift
+++ b/Capture/CaptureManager.swift
@@ -413,7 +413,7 @@ final class CaptureManager: NSObject, ObservableObject {
         let cropRect = makeCropRect(source: sourceDims, output: outDims)
 
         let outputURL = generateOutputURL()
-        let fileType: AVFileType = recordingMode == .audioOnly ? AppSettings.shared.audioFormat.avFileType : .mov
+        let fileType: AVFileType = recordingMode == .audioOnly ? AppSettings.shared.audioFormat.avFileType : AppSettings.shared.videoFormat.avFileType
 
         guard let writer = try? AVAssetWriter(outputURL: outputURL, fileType: fileType) else {
             DispatchQueue.main.async { self.lastError = "Could not create output file at \(outputURL.path)." }
@@ -550,7 +550,7 @@ final class CaptureManager: NSObject, ObservableObject {
     private func generateOutputURL() -> URL {
         let fmt = DateFormatter()
         fmt.dateFormat = "yyyy-MM-dd_HHmmss"
-        let ext = recordingMode == .audioOnly ? AppSettings.shared.audioFormat.fileExtension : "mov"
+        let ext = recordingMode == .audioOnly ? AppSettings.shared.audioFormat.fileExtension : AppSettings.shared.videoFormat.fileExtension
         let name = "Radcap_\(fmt.string(from: Date())).\(ext)"
         return AppSettings.shared.effectiveOutputDirectory.appendingPathComponent(name)
     }

--- a/Models/AppSettings.swift
+++ b/Models/AppSettings.swift
@@ -13,6 +13,14 @@ final class AppSettings: ObservableObject {
         var avFileType: AVFileType  { self == .m4a ? .m4a  : .wav  }
     }
 
+    enum VideoFormat: String, CaseIterable, Identifiable {
+        case mov = "MOV"
+        case mp4 = "MP4"
+        var id: String { rawValue }
+        var fileExtension: String { self == .mov ? "mov" : "mp4" }
+        var avFileType: AVFileType  { self == .mov ? .mov  : .mp4  }
+    }
+
     static var isSandboxed: Bool {
         ProcessInfo.processInfo.environment["APP_SANDBOX_CONTAINER_ID"] != nil
     }
@@ -21,6 +29,7 @@ final class AppSettings: ObservableObject {
         static let outputDirectoryPath          = "outputDirectoryPath"
         static let outputDirectoryBookmark      = "outputDirectoryBookmark"
         static let audioFormat                  = "audioFormat"
+        static let videoFormat                  = "videoFormat"
         static let teleprompterText             = "teleprompterText"
         static let teleprompterSpeed            = "teleprompterSpeed"
         static let teleprompterFontSize         = "teleprompterFontSize"
@@ -87,6 +96,9 @@ final class AppSettings: ObservableObject {
     @Published var audioFormat: AudioFormat {
         didSet { UserDefaults.standard.set(audioFormat.rawValue, forKey: Key.audioFormat) }
     }
+    @Published var videoFormat: VideoFormat {
+        didSet { UserDefaults.standard.set(videoFormat.rawValue, forKey: Key.videoFormat) }
+    }
 
     private init() {
         if AppSettings.isSandboxed,
@@ -124,6 +136,8 @@ final class AppSettings: ObservableObject {
         recordingPreviewOpacity = opacity > 0 ? opacity : 0.6
         let fmtRaw = UserDefaults.standard.string(forKey: Key.audioFormat) ?? ""
         audioFormat = AudioFormat(rawValue: fmtRaw) ?? .m4a
+        let vfmtRaw = UserDefaults.standard.string(forKey: Key.videoFormat) ?? ""
+        videoFormat = VideoFormat(rawValue: vfmtRaw) ?? .mov
     }
 
     var effectiveOutputDirectory: URL {

--- a/Views/SettingsView.swift
+++ b/Views/SettingsView.swift
@@ -42,6 +42,16 @@ struct SettingsView: View {
                         .foregroundColor(.secondary)
                         .font(.caption)
                     }
+                    LabeledContent("Video Format") {
+                        Picker("", selection: $settings.videoFormat) {
+                            ForEach(AppSettings.VideoFormat.allCases) { f in
+                                Text(f.rawValue).tag(f)
+                            }
+                        }
+                        .labelsHidden()
+                        .help("Container format for video recordings (MOV and MP4 both use H.264)")
+                        .accessibilityLabel("Video Format")
+                    }
                     LabeledContent("Audio Format") {
                         Picker("", selection: $settings.audioFormat) {
                             ForEach(AppSettings.AudioFormat.allCases) { f in


### PR DESCRIPTION
## Summary

- Adds `AppSettings.VideoFormat` enum (`MOV` / `MP4`) with `avFileType` and `fileExtension` properties
- Persists selection to UserDefaults under `"videoFormat"`, defaults to MOV
- Replaces two hardcoded `.mov` / `"mov"` literals in `CaptureManager.startRecording()` and `generateOutputURL()`
- Adds **Video Format** picker to the Output section of Settings (above Audio Format)

Both formats use H.264 — MP4 improves compatibility with social platforms and non-Apple players.

Closes #38

## Test plan

- [ ] Settings shows Video Format picker with MOV / MP4 options
- [ ] MOV recording produces a `.mov` file
- [ ] MP4 recording produces a `.mp4` file that plays in QuickTime and VLC
- [ ] Selection persists across app restarts
- [ ] Audio Only mode is unaffected (still uses Audio Format setting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)