### PR TITLE
feat(agent-network): bootstrap CLAUDE.md + agent-dispatch workflow

### DIFF
--- a/.github/workflows/agent-dispatch.yml
+++ b/.github/workflows/agent-dispatch.yml
@@ -1,0 +1,69 @@
+name: Agent Dispatch
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  dispatch:
+    if: github.event.label.name == 'agent-dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Run subagent
+        uses: actions/github-script@v7
+        env:
+          TRACKER_API_TOKEN: ${{ secrets.TRACKER_API_TOKEN }}
+        with:
+          script: |
+            const body = context.payload.issue.body || '';
+            const match = body.match(/^subagent:\s*(\S+)/m);
+            const subagent = match ? match[1].trim() : null;
+
+            if (!subagent) {
+              await github.rest.issues.createComment({
+                ...context.repo, issue_number: context.issue.number,
+                body: '### ⚠️ Agent Dispatch Error\n\nMissing `subagent:` field.\n\n**Expected format:**\n```\nsubagent: <name>\ncaller: <repo>/<issue>\n```\n\nValid subagents: `format-release-notes`, `report-pipeline-status`'
+              });
+              return;
+            }
+
+            let result = `⚠️ Unknown subagent \`${subagent}\`. Valid: \`format-release-notes\`, \`report-pipeline-status\`\n\nSee [roles manifest](https://github.com/sfegette/bmw-dev-stack/blob/main/docs/agent-roles-manifest.md).`;
+
+            if (subagent === 'format-release-notes') {
+              result = `⚠️ \`format-release-notes\` not yet implemented. File a follow-up in ${context.repo.repo} to wire this up with the Claude Code API.`;
+            } else if (subagent === 'report-pipeline-status') {
+              const token = process.env.TRACKER_API_TOKEN;
+              if (!token) {
+                result = '⚠️ `TRACKER_API_TOKEN` secret not set — configure in repo Settings → Secrets and variables → Actions. See bmw-dev-stack for the token value.';
+              } else {
+                const callerMatch = body.match(/^caller:\s*(.+)/m);
+                const contextMatch = body.match(/^context:\s*(.+)/m);
+                try {
+                  const res = await fetch('https://tracker.scottfegette.com/api/ping', {
+                    method: 'POST',
+                    headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                      repo: context.repo.repo,
+                      event: 'pipeline-status',
+                      subagent: 'report-pipeline-status',
+                      issue: context.issue.number,
+                      caller: callerMatch ? callerMatch[1].trim() : 'unknown',
+                      context: contextMatch ? contextMatch[1].trim() : '',
+                      timestamp: new Date().toISOString()
+                    })
+                  });
+                  result = res.ok
+                    ? `✅ Pipeline status reported to tracker (HTTP ${res.status})`
+                    : `❌ Tracker returned HTTP ${res.status}: ${await res.text()}`;
+                } catch (e) {
+                  result = `❌ Tracker ping failed: ${e.message}`;
+                }
+              }
+            }
+
+            await github.rest.issues.createComment({
+              ...context.repo, issue_number: context.issue.number,
+              body: `### Agent Dispatch — \`${subagent}\`\n\n${result}\n\n---\n*[Roles Manifest](https://github.com/sfegette/bmw-dev-stack/blob/main/docs/agent-roles-manifest.md)*`
+            });

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,51 @@
+# CLAUDE.md — radcap
+
+This file provides guidance to Claude Code when working with code in this repository.
+
+> **Note to radcap agent:** This CLAUDE.md was bootstrapped by the bmw-dev-stack meta-agent as part of agent network v0.1 (2026-06-09). Please flesh out the Build, Architecture, and Key Patterns sections based on the actual codebase in your next session.
+
+---
+
+## Agent Role
+
+**Role:** Apple platform leaf node
+
+radcap is a leaf node in the Brilliant Mindworks five-repo agent network. It owns the radcap iOS/macOS app and its build/release pipeline.
+
+| | |
+|---|---|
+| **Hierarchy** | Leaf |
+| **Reports to** | Scott Fegette |
+| **Visibility** | Public repo — role-filter all cross-repo files |
+
+**Local subagents** (callable by peer agents via `agent-dispatch` label on this repo):
+
+| Subagent | Status | What it does |
+|---|---|---|
+| `format-release-notes` | stub | Format release notes from commits/changelog |
+| `report-pipeline-status` | ✅ live | Ping tracker with current build/pipeline state |
+
+**Incoming routes:** cross-repo requests from bmw-dev-stack  
+**Outgoing routes:** infra/backend work → sfegette/bmw-dev-stack; public pages → sfegette/brilliant-web
+
+**Role-filter rule (public repo):** Before writing anything to a cross-repo file, ask: "Would this be fine on a public GitHub page?" If no → route to bmw-dev-stack.
+
+**Canonical reference:** [Roles Manifest](https://github.com/sfegette/bmw-dev-stack/blob/main/docs/agent-roles-manifest.md)
+
+---
+
+## Build & Run
+
+> TODO: Document build commands, Xcode scheme, test target, simulator destination.
+
+---
+
+## Architecture
+
+> TODO: Document app architecture, key files, state management, and design decisions.
+
+---
+
+## HITL Thresholds
+
+See [roles manifest](https://github.com/sfegette/bmw-dev-stack/blob/main/docs/agent-roles-manifest.md#hitl-thresholds). Key rules: open PR → HITL; merge PR → always HITL; push release/tag → always HITL; file issues / ping tracker → autonomous.


### PR DESCRIPTION
## Summary

- **`CLAUDE.md`** — new file; establishes radcap's Agent Role as a leaf node in the Brilliant Mindworks network; Build/Architecture sections are stubs for the radcap agent to fill in
- **`.github/workflows/agent-dispatch.yml`** — `report-pipeline-status` live (pings tracker); `format-release-notes` stubbed

## Context

radcap is a **public repo leaf node**. All internal coordination routes up to bmw-dev-stack; public-facing content routes to brilliant-web.

**Canonical reference:** https://github.com/sfegette/bmw-dev-stack/blob/main/docs/agent-roles-manifest.md

## Action needed after merge

1. Create the `agent-dispatch` label:
   ```bash
   gh label create agent-dispatch --repo sfegette/radcap --color 0075ca --description "Triggers agent subagent dispatch"
   ```
2. Add `TRACKER_API_TOKEN` to repo Secrets (Settings → Secrets → Actions) — get the value from bmw-dev-stack
3. Fill in the `## Build & Run` and `## Architecture` sections in CLAUDE.md

## Related

- Part of agent network v0.1 bootstrap — see bmw-dev-stack#40
- Companion PRs: bmw-dev-stack, brilliant-web, grapfel, chordale (all feat/agent-role)

🤖 Generated with [Claude Code](https://claude.com/claude-code)