### PR TITLE
feat(release): dispatch app-page update to brilliant-web on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,3 +50,21 @@ jobs:
           else
             ./scripts/release.sh --ndd --no-tag
           fi
+
+      - name: Dispatch app-page update to brilliant-web
+        if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run == 'true') }}
+        env:
+          GH_TOKEN: ${{ secrets.BRILLIANT_WEB_PAT }}
+        run: |
+          VERSION="${{ github.ref_name }}"
+          CHANGELOG=$(git log -1 --pretty=format:"%s")
+          gh issue create \
+            --repo sfegette/brilliant-web \
+            --title "agent-dispatch: update-app-page $VERSION" \
+            --label agent-dispatch \
+            --body "subagent: update-app-page
+          params:
+            version: $VERSION
+            changelog: $CHANGELOG
+          caller: radcap/${{ github.run_id }}
+          context: automated dispatch from radcap release.yml"


### PR DESCRIPTION
## Summary

- Adds a post-release dispatch step to `release.yml` that fires a GitHub issue on `sfegette/brilliant-web` with the `agent-dispatch` label
- Triggers the `update-app-page` subagent on brilliant-web with version + changelog on every real release (skipped on dry runs)
- Uses `BRILLIANT_WEB_PAT` secret (now live in repo secrets) scoped only to this step
- Closes #45

## Test plan

- [ ] Merge and verify the next release fires an `agent-dispatch` issue on brilliant-web
- [ ] Confirm dry-run workflow dispatch correctly skips the step
- [ ] Confirm brilliant-web `update-app-page` subagent picks up the dispatched issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)